### PR TITLE
Update MMM-PlaceInfo.js

### DIFF
--- a/MMM-PlaceInfo.js
+++ b/MMM-PlaceInfo.js
@@ -54,7 +54,7 @@ Module.register("MMM-PlaceInfo", {
       "50n": "wi-night-alt-cloudy-windy"
     },
 
-    currencyAPI: "http://data.fixer.io/api/latest",
+    currencyAPI: "https://api.apilayer.com/fixer/latest",
     currencyBase: "EUR", // cannot change, unless you're using a paid-up plan.
     currencyRelativeTo: "EUR",
     currencyReversed: false,
@@ -457,7 +457,7 @@ Module.register("MMM-PlaceInfo", {
     if (this.config.currencyBase != this.config.currencyRelativeTo) {
       currencies[this.config.currencyRelativeTo] = 1;
     }
-    params = "?access_key=" + this.config.currencyAPIKey;
+    params = "?apikey=" + this.config.currencyAPIKey;
     params += "&base=" + this.config.currencyBase;
     params += "&symbols=" + Object.keys(currencies).join();
     return params;


### PR DESCRIPTION
The currency feature was not working, it didn't recognize the API key since the base URL and API parameter changed. Updated line 57. The currencyAPI value has been updated from "http://data.fixer.io/api/latest" to "https://api.apilayer.com/fixer/latest".
Updated line 460.  From params= "?access_key=" + this.config.currencyAPIKey; to params= "?apikey=" + this.config.currencyAPIKey;